### PR TITLE
Fix reputation icons not showing

### DIFF
--- a/styles/prosilver/theme/reputation_common.css
+++ b/styles/prosilver/theme/reputation_common.css
@@ -129,9 +129,25 @@
 	height: 16px;
 }
 
-.reputation-rating.positive.image { background-image: url("./images/pos.png"); }
+.reputation-rating.positive.image::before,
+.reputation-rating.negative.image::before {
+	display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+	font-family: "FontAwesome";
+	font-weight: 900;
+	font-size: 14px;
+}
 
-.reputation-rating.negative.image { background-image: url("./images/neg.png"); }
+.reputation-rating.positive.image::before {
+	content: "\f055";
+}
+
+.reputation-rating.negative.image::before {
+	content: "\f056";
+}
 
 .reputation-action {
 	margin-bottom: 5px;
@@ -215,5 +231,5 @@
 
 #post-reputation-list::-webkit-scrollbar-thumb {
 	border-radius: 10px;
-	-webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5); 
+	-webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
 }


### PR DESCRIPTION
Reputation icons were not loading since CSS referenced the now-deleted pos.png / neg.png. Switched over to using fontawesome like the trash icon already does, all in CSS.